### PR TITLE
fix use of region in config

### DIFF
--- a/botoenv/main.py
+++ b/botoenv/main.py
@@ -4,6 +4,7 @@ Capture and export AWS credentials.
 """
 from argparse import ArgumentParser
 from sys import stdout
+import os
 
 from botocore.session import Session
 
@@ -20,6 +21,7 @@ def parse_args():
 
 
 def build_credentials_map(session, credentials):
+    del os.environ["AWS_DEFAULT_REGION"]
     if credentials.token is None:
         return dict(
             AWS_DEFAULT_REGION=session.get_config_variable("region"),

--- a/botoenv/main.py
+++ b/botoenv/main.py
@@ -2,8 +2,8 @@
 Capture and export AWS credentials.
 
 """
-import os
 from argparse import ArgumentParser
+from os import environ
 from sys import stdout
 
 from botocore.session import Session

--- a/botoenv/main.py
+++ b/botoenv/main.py
@@ -2,9 +2,9 @@
 Capture and export AWS credentials.
 
 """
+import os
 from argparse import ArgumentParser
 from sys import stdout
-import os
 
 from botocore.session import Session
 

--- a/botoenv/main.py
+++ b/botoenv/main.py
@@ -21,7 +21,7 @@ def parse_args():
 
 
 def build_credentials_map(session, credentials):
-    del os.environ["AWS_DEFAULT_REGION"]
+    del environ["AWS_DEFAULT_REGION"]
     if credentials.token is None:
         return dict(
             AWS_DEFAULT_REGION=session.get_config_variable("region"),


### PR DESCRIPTION
**Problem Statement**
AWS_DEFAULT_REGION value does not change upon profile switch where it specifies to use a different region.

This is because pre-existing environment variable AWS_DEFAULT_REGION takes precedence over other value retrieved afterwards.  By deleting this environment variable, region value established in .aws/config will be used.